### PR TITLE
"Fixed the issue of temp.png not found due to relative path by switching to an absolute path."

### DIFF
--- a/cellbin2/modules/report_m.py
+++ b/cellbin2/modules/report_m.py
@@ -3,6 +3,7 @@ import os
 import re
 from cellbin2.modules.report.min_html import operat_html
 
+
 CURR_PATH = os.path.dirname(os.path.realpath(__file__))
 REPORT_MODULE = os.path.join(CURR_PATH, "report")
 RESULT_JSON_PARH = os.path.join(REPORT_MODULE, 'js')
@@ -15,7 +16,6 @@ COLORS = ["#E64B35", "#4DBBD5", "#00A087", "#3C5488", "#F39B7F", "#8491B4", "#91
           "#EE4C97", "#00468B", "#ED0000", "#42B540", "#0099B4", "#925E9F", "#FDAF91", "#AD002A", "#ADB6B6",
           "#1B1919", "#374E55", "#DF8F44", "#00A1D5", "#B24745", "#79AF97", "#6A6599", "#80796B", "#0073C2",
           "#EFC000", "#868686", "#CD534C", "#7AA6DC", "#003C67"]
-
 
 class Report(object):
     """ 报告: 不限制形式（HTML ） """
@@ -37,12 +37,14 @@ class Report(object):
         self._json["sampleId"] = self.matrics_data["infor"]["sampleId"]
         self._json["pipelineVersion"] = self.matrics_data["infor"]["pipelineVersion"]
 
+
     def _javascript_tojson(self, jstring):
         json_data = jstring.split('resultJson = ')[1].strip().strip(';')
         return json_data
 
     def save_js(self):
         save_file = os.path.join(self.save_path, "result.js")
+        print(f"savejspath: {save_file}")
         js_code = f"const resultJson = {self._json};"
         with open(save_file, "w") as file:
             file.write(js_code)
@@ -198,7 +200,8 @@ class Report(object):
                 temp_dict["marker"]["size"] = 1.56
                 temp_dict["marker"]["opacity"] = 1.0
                 temp_dict["marker"]["symbol"] = "circle"
-                temp_dict["marker"]["color"] = COLORS[i]
+                # temp_dict["marker"]["color"] = COLORS[i]
+                temp_dict["marker"]["color"] = COLORS[i % len(COLORS)] #循环颜色
                 self._json["cellbin"][matrix_type]["clustering"]["data"]["spatial"].append(temp_dict)
                 temp_dict = {"mode": "markers", "name": f"Cluster {c}", "type": "scattergl", "hovertemplate": " ",
                              "marker": {}}
@@ -206,7 +209,8 @@ class Report(object):
                 temp_dict["marker"]["size"] = 1.56
                 temp_dict["marker"]["opacity"] = 1.0
                 temp_dict["marker"]["symbol"] = "circle"
-                temp_dict["marker"]["color"] = COLORS[i]
+                # temp_dict["marker"]["color"] = COLORS[i]
+                temp_dict["marker"]["color"] = COLORS[i % len(COLORS)] #循环颜色
                 self._json["cellbin"][matrix_type]["clustering"]["data"]["umap"].append(temp_dict)
 
         if len(self.matrics_data["matrix"]["RNA"]["cluster"]) > 0:
@@ -368,7 +372,7 @@ class Report(object):
 
 
 def creat_report(matric_json, save_path):
-    report = Report(matrics_json=matric_json)
+    report = Report(matrics_json=matric_json, save_path=save_path)
     report.setparam()
     report.save_js()
     os.chdir(REPORT_MODULE)
@@ -381,8 +385,8 @@ def creat_report(matric_json, save_path):
 
 def main():
     creat_report(
-        matric_json=r"F:\01.users\hedongdong\cellbin2_test\report_result\pipline\report\metrics.json",
-        save_path=r"F:\01.users\hedongdong\cellbin2_test\report_result\pipline\report")
+        matric_json=r"/storeData/USER/data/01.CellBin/00.user/shenzilei/output/t3/metrics.json",
+        save_path=r"/storeData/USER/data/01.CellBin/00.user/shenzilei/save_p/t3")
 
 
 if __name__ == '__main__':

--- a/cellbin2/utils/matrix.py
+++ b/cellbin2/utils/matrix.py
@@ -281,11 +281,11 @@ class cbMatrix(object):
 
 
 class BinMatrix(object):
-    def __init__(self, file_path: str, bin_read=100):
+    def __init__(self, file_path: str,save_path: str, bin_read=100):
         self._file_path = file_path
         self._stereo_exp = None  ### raw stereo_exp
         self._bin_read = bin_read
-
+        self.out_path = save_path
     def reset(self):
         self._stereo_exp = None
 
@@ -309,7 +309,7 @@ class BinMatrix(object):
         if self._file_path.endswith(".gef"):
             from stereo.io import read_gef, read_gef_info
             data = read_gef(self._file_path, bin_size=bin_size)
-        return data
+            return data
 
     def get_total_MID(self):
         return self.stereo_exp._exp_matrix.sum()
@@ -334,12 +334,13 @@ class BinMatrix(object):
                                                          (0.66, '#f28f38'), (0.77, '#f48f38'), (0.88, '#d91e1e'),
                                                          (1.0, '#d91e1e')])
         cmap.set_under('k', alpha=0)
-        plt.imsave('./temp.png', heatmap_array, vmin=1, cmap=cmap)
+        out_path = os.path.join(self.out_path,"temp.png")
+        plt.imsave(out_path, heatmap_array, vmin=1, cmap=cmap)
 
-        with open('./temp.png', "rb") as f:
+        with open(out_path, "rb") as f:
             img_b = f.read()
             b = io.BytesIO(img_b)  ## heatmap img
-        os.remove('./temp.png')
+        os.remove(out_path)
         fig, ax = plt.subplots(figsize=(1, 1))
         norm = colors.Normalize(vmin=0, vmax=df['plot_data'].max())
         im = cm.ScalarMappable(norm=norm, cmap=cmap)
@@ -354,11 +355,11 @@ class BinMatrix(object):
 
         cbar = plt.colorbar(im, ax=ax, format=ticker.FuncFormatter(human_format))
         ax.remove()
-        plt.savefig('./temp.png', bbox_inches='tight')
-        with open('./temp.png', "rb") as f:
+        plt.savefig(out_path, bbox_inches='tight')
+        with open(out_path, "rb") as f:
             img_c = f.read()
             c = io.BytesIO(img_c)  # color bar
-        os.remove('./temp.png')
+        os.remove(out_path)
 
         return ('data:image/png;base64,{}'.format(base64.b64encode(b.getvalue()).decode()),
                 'data:image/png;base64,{}'.format(base64.b64encode(c.getvalue()).decode()))
@@ -367,7 +368,7 @@ class BinMatrix(object):
 class MultiMatrix(object):
     """ 联合管理多个矩阵：可能需要 """
 
-    def __init__(self, cellbin_path, adjusted_path, tissuegef_path, raw_path, matrix_type: TechType):
+    def __init__(self, cellbin_path, adjusted_path, tissuegef_path, raw_path, matrix_type: TechType,save_path):
 
         self.cellbin = None
         self.tissuebin = None
@@ -378,9 +379,9 @@ class MultiMatrix(object):
         if not cellbin_path == "":
             self.cellbin = cbMatrix(cellbin_path,matrix_type=self.matrix_type)
         if not tissuegef_path == "":
-            self.tissuebin = BinMatrix(tissuegef_path, bin_read=10)
+            self.tissuebin = BinMatrix(tissuegef_path, bin_read=10,save_path=save_path)
         if not raw_path == "":
-            self.rawbin = BinMatrix(raw_path, bin_read=10)
+            self.rawbin = BinMatrix(raw_path, bin_read=10,save_path=save_path)
         if not adjusted_path == "":
             self.adjustedbin = cbMatrix(adjusted_path,matrix_type=self.matrix_type)
 


### PR DESCRIPTION
When running matrix.py, due to the use of relative paths, the temp.png file cannot be found, causing a path error. It has been fixed to an absolute path and has been tested. The temp.png file can be loaded normally and no other abnormalities were found.